### PR TITLE
Fix Next.js to Vite migration: Update Tailwind config paths

### DIFF
--- a/CLEANUP.md
+++ b/CLEANUP.md
@@ -1,0 +1,55 @@
+# Next.js to Vite Migration Cleanup
+
+This branch contains the fixes needed to complete your Next.js to Vite migration.
+
+## Changes Made
+
+### ✅ Fixed Files
+- **tailwind.config.ts**: Updated content paths from Next.js (`./pages/**/*`, `./app/**/*`) to Vite (`./src/**/*`, `./index.html`)
+
+### 🗑️ Files That Need Manual Deletion
+The following Next.js configuration files should be deleted as they're no longer needed:
+
+1. **next.config.mjs** - Next.js configuration file
+2. **postcss.config.mjs** - Duplicate PostCSS config (keep postcss.config.js)
+
+## Manual Cleanup Steps
+
+After merging this branch:
+
+1. Delete the unused files:
+   ```bash
+   rm next.config.mjs
+   rm postcss.config.mjs
+   ```
+
+2. Remove old lock files if switching package managers:
+   ```bash
+   rm package-lock.json  # if using pnpm or bun
+   rm pnpm-lock.yaml     # if using npm or pnpm  
+   rm bun.lockb          # if using npm or pnpm
+   ```
+
+3. Clean install dependencies:
+   ```bash
+   npm ci  # or pnpm install, or bun install
+   ```
+
+## Your Current State
+
+✅ **Your package.json is already properly configured for Vite**
+✅ **Your project structure is already Vite-based** 
+✅ **All necessary Vite dependencies are installed**
+✅ **Tailwind config now has correct Vite paths**
+
+The migration is essentially complete! You just need to clean up the old Next.js files.
+
+## Testing
+
+After cleanup, test that everything works:
+
+```bash
+npm run dev      # Start development server
+npm run build    # Test production build
+npm run preview  # Test production preview
+```

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,10 +3,8 @@ import type { Config } from "tailwindcss"
 const config: Config = {
   darkMode: ["class"],
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx,mdx}",
-    "./components/**/*.{js,ts,jsx,tsx,mdx}",
-    "./app/**/*.{js,ts,jsx,tsx,mdx}",
-    "*.{js,ts,jsx,tsx,mdx}",
+    "./src/**/*.{js,ts,jsx,tsx,mdx}",
+    "./index.html",
   ],
   theme: {
     extend: {


### PR DESCRIPTION
This PR completes the Next.js to Vite migration cleanup by fixing the remaining configuration issues.

## Changes Made

### ✅ Fixed Files
- **tailwind.config.ts**: Updated content paths from Next.js structure (`./pages/**/*`, `./app/**/*`) to Vite structure (`./src/**/*`, `./index.html`)

### 📋 Manual Cleanup Required
After merging this PR, you'll need to manually delete these Next.js remnant files:
- `next.config.mjs` - No longer needed with Vite
- `postcss.config.mjs` - Duplicate file (keep `postcss.config.js`)

## Current Migration Status

✅ **package.json** - Already properly configured for Vite  
✅ **Project structure** - Already using Vite structure (`src/`, `index.html`)  
✅ **Dependencies** - All Vite dependencies installed  
✅ **Tailwind config** - Now has correct Vite paths  
✅ **Build system** - Vite configuration in place  

## What This Fixes

The main issue was that your Tailwind configuration was still looking for files in Next.js locations (`./pages/**/*`, `./app/**/*`) instead of the Vite structure (`./src/**/*`). This could cause:
- Tailwind classes not being detected
- CSS purging issues
- Build inconsistencies

## Testing

After merging and cleanup:
```bash
rm next.config.mjs postcss.config.mjs
npm run dev      # Should work without issues
npm run build    # Should build successfully  
npm run preview  # Should preview built app
```

Your migration is essentially complete! 🎉